### PR TITLE
Dealing with doc-strings with @Lazy.

### DIFF
--- a/src/zope/cachedescriptors/property.py
+++ b/src/zope/cachedescriptors/property.py
@@ -1,7 +1,7 @@
 ##############################################################################
 # Copyright (c) 2003 Zope Foundation and Contributors.
 # All Rights Reserved.
-# 
+#
 # This software is subject to the provisions of the Zope Public License,
 # Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
 # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
@@ -60,6 +60,7 @@ class Lazy(object):
         if name is None:
             name = func.__name__
         self.data = (func, name)
+        self.__doc__ = func.__doc__
 
     def __get__(self, inst, class_):
         if inst is None:
@@ -68,7 +69,6 @@ class Lazy(object):
         func, name = self.data
         value = func(inst)
         inst.__dict__[name] = value
-
         return value
 
 

--- a/src/zope/cachedescriptors/property.txt
+++ b/src/zope/cachedescriptors/property.txt
@@ -131,6 +131,34 @@ want to use a different name, we need to pass it:
     computing diameter
     '5.66'
 
+Documentation is preserved if the attribute is accessed through
+the class. This allows Sphinx to extract the documentation.
+
+    >>> class Point:
+    ... 
+    ...     def __init__(self, x, y):
+    ...         self.x, self.y = x, y
+    ...
+    ...     @property.Lazy
+    ...     def radius(self):
+    ...         '''The length of the line between self.x and self.y'''
+    ...         print('computing radius')
+    ...         return math.sqrt(self.x**2 + self.y**2)
+
+    >>> print(Point.radius.__doc__)
+    The length of the line between self.x and self.y
+
+The documentation of the attribute when accessed through the
+instance will be the same as the return-value:
+
+   >>> p = Point(1.0, 2.0)
+   >>> print (p.radius.__doc__)
+   computing radius
+   float(x) -> floating point number
+   ...
+
+This is the same behaviour as the standard Python ``property``
+decorator.
 
 readproperty
 ~~~~~~~~~~~~


### PR DESCRIPTION
A small update to the `Lazy` decorator so it copies the `__doc__` from the wrapped function. This allows Sphinx to pull in the docstring.