### PR TITLE
method.cachedIn preserves __doc__, etc

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ Changes
 - ``property.CachedProperty`` is usable as a decorator, with or
   without dependent attribute names.
 
+- ``method.cachedIn`` preserves the documentation string of the
+  underlying function, and everything else that ``functools.wraps`` preserves.
+
 4.1.0 (2014-12-26)
 ------------------
 

--- a/src/zope/cachedescriptors/method.py
+++ b/src/zope/cachedescriptors/method.py
@@ -1,7 +1,7 @@
 ##############################################################################
 # Copyright (c) 2007 Zope Foundation and Contributors.
 # All Rights Reserved.
-# 
+#
 # This software is subject to the provisions of the Zope Public License,
 # Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
 # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
@@ -12,6 +12,8 @@
 """Cached Methods
 """
 
+from functools import wraps
+
 class cachedIn(object):
     """Cached method with given cache attribute."""
 
@@ -21,6 +23,7 @@ class cachedIn(object):
 
     def __call__(self, func):
 
+        @wraps(func)
         def decorated(instance, *args, **kwargs):
             cache = self.cache(instance)
             key = self._get_cache_key(*args, **kwargs)

--- a/src/zope/cachedescriptors/method.py
+++ b/src/zope/cachedescriptors/method.py
@@ -14,6 +14,7 @@
 
 from functools import wraps
 
+
 class cachedIn(object):
     """Cached method with given cache attribute."""
 

--- a/src/zope/cachedescriptors/method.txt
+++ b/src/zope/cachedescriptors/method.txt
@@ -11,16 +11,17 @@ computed value:
     >>> from zope.cachedescriptors import method
 
     >>> class Point(object):
-    ... 
+    ...
     ...     def __init__(self, x, y):
     ...         self.x, self.y = x, y
     ...
     ...     @method.cachedIn('_cache')
     ...     def distance(self, x, y):
+    ...         "Compute the distance"
     ...         print('computing distance')
     ...         return math.hypot(self.x - x, self.y - y)
     ...
-    >>> point = Point(1.0, 2.0)   
+    >>> point = Point(1.0, 2.0)
 
 The value is computed once:
 
@@ -60,6 +61,18 @@ Invalidating keys which are not in the cache, does not result in an error:
 
     >>> point.distance.invalidate(point, 47, 11)
 
+The documentation of the function is preserved (whether through the
+instance or the class), allowing Sphinx to extract it::
+
+    >>> print(point.distance.__doc__)
+    Compute the distance
+    >>> print(point.distance.__name__)
+    distance
+
+    >>> print(Point.distance.__doc__)
+    Compute the distance
+    >>> print(Point.distance.__name__)
+    distance
 
 It is possible to pass in a factory for the cache attribute. Create another
 Point class:
@@ -68,7 +81,7 @@ Point class:
     >>> class MyDict(dict):
     ...     pass
     >>> class Point(object):
-    ... 
+    ...
     ...     def __init__(self, x, y):
     ...         self.x, self.y = x, y
     ...
@@ -77,7 +90,7 @@ Point class:
     ...         print('computing distance')
     ...         return math.sqrt((self.x - x)**2 + (self.y - y)**2)
     ...
-    >>> point = Point(1.0, 2.0)   
+    >>> point = Point(1.0, 2.0)
     >>> point.distance(2, 2)
     computing distance
     1.0

--- a/src/zope/cachedescriptors/method.txt
+++ b/src/zope/cachedescriptors/method.txt
@@ -17,7 +17,7 @@ computed value:
     ...
     ...     @method.cachedIn('_cache')
     ...     def distance(self, x, y):
-    ...         "Compute the distance"
+    ...         """Compute the distance"""
     ...         print('computing distance')
     ...         return math.hypot(self.x - x, self.y - y)
     ...

--- a/src/zope/cachedescriptors/property.py
+++ b/src/zope/cachedescriptors/property.py
@@ -56,6 +56,7 @@ class _CachedProperty(object):
 
         return value
 
+
 def CachedProperty(*args):
     """
     CachedProperties.


### PR DESCRIPTION
This is done using functools.wraps so the exact wrapping depends on
Python version.

This doesn't include an update to CHANGES.rst because of conflicts with
PR #4 and #6.