### PR TITLE
Add Python 3.6 and drop Python 3.3

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[run]
+source = zope.cachedescriptors
+
+[report]
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__':
+    raise NotImplementedError
+    self.fail

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.egg-info
 *.pyc
 .tox/
+.coverage
+htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,19 @@ language: python
 sudo: false
 python:
     - 2.7
-    - 3.3
     - 3.4
     - 3.5
+    - 3.6
     - pypy
-    - pypy3
+    - pypy3.5-5.8.0
 install:
-    - pip install .
+    - pip install -U pip setuptools
+    - pip install -U coverage coveralls
+    - pip install -U -e .[test]
 script:
-    - python setup.py test -q
+    - coverage run setup.py -q test -q
+after_success:
+    - coveralls
 notifications:
     email: false
+cache: pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,14 +1,17 @@
-Changes
-=======
+=========
+ Changes
+=========
 
 4.2.1 (unreleased)
-------------------
+==================
 
-- Nothing changed yet.
+- Add support for Python 3.6.
+
+- Drop support for Python 3.3.
 
 
 4.2.0 (2016-09-05)
-------------------
+==================
 
 - Add support for Python 3.5.
 
@@ -26,7 +29,7 @@ Changes
   underlying function, and everything else that ``functools.wraps`` preserves.
 
 4.1.0 (2014-12-26)
-------------------
+==================
 
 - Add support for PyPy and PyPy3.
 
@@ -36,7 +39,7 @@ Changes
 
 
 4.0.0 (2013-02-13)
-------------------
+==================
 
 - Drop support for Python 2.4 and 2.5.
 
@@ -44,12 +47,12 @@ Changes
 
 
 3.5.1 (2010-04-30)
-------------------
+==================
 
 - Remove undeclared testing dependency on zope.testing.
 
 3.5.0 (2009-02-10)
-------------------
+==================
 
 - Remove dependency on ZODB by allowing to specify storage factory for
   ``zope.cachedescriptors.method.cachedIn`` which is now ``dict`` by default.
@@ -64,6 +67,6 @@ Changes
   zope3-dev at zope.org is now retired.
 
 3.4.0 (2007-08-30)
-------------------
+==================
 
 Initial release as an independent package

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,10 @@
-include *.txt bootstrap.py buildout.cfg tox.ini *.rst
-recursive-include src *.py *.txt *.zcml
+include *.txt
+include bootstrap.py
+include buildout.cfg
+include tox.ini
+include *.rst
+include .travis.yml
+include .coveragerc
+
+recursive-include src *.py
+recursive-include src *.rst

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,24 @@
-``zope.cachedescriptors``
-=========================
+===========================
+ ``zope.cachedescriptors``
+===========================
+
+.. image:: https://img.shields.io/pypi/v/zope.cachedescriptors.svg
+        :target: https://pypi.python.org/pypi/zope.cachedescriptors/
+        :alt: Latest release
+
+.. image:: https://img.shields.io/pypi/pyversions/zope.cachedescriptors.svg
+        :target: https://pypi.org/project/zope.cachedescriptors/
+        :alt: Supported Python versions
 
 .. image:: https://travis-ci.org/zopefoundation/zope.cachedescriptors.png?branch=master
         :target: https://travis-ci.org/zopefoundation/zope.cachedescriptors
+
+.. image:: https://readthedocs.org/projects/zopehookable/badge/?version=latest
+        :target: http://zopehookable.readthedocs.io/en/latest/
+        :alt: Documentation Status
+
+.. image:: https://coveralls.io/repos/github/zopefoundation/zope.cachedescriptors/badge.svg?branch=master
+        :target: https://coveralls.io/github/zopefoundation/zope.cachedescriptors?branch=master
 
 Cached descriptors cache their output.  They take into account
 instance attributes that they depend on, so when the instance
@@ -18,8 +34,8 @@ Persistent descriptors:
 - ``property``
 
   A simple computed property.
-     
-  See ``src/zope/cachedescriptors/property.txt``.
+
+  See ``src/zope/cachedescriptors/property.rst``.
 
 - ``method``
 
@@ -28,7 +44,7 @@ Persistent descriptors:
   defined to depend on.
 
   .. note::
-  
+
      Only a cache based on arguments has been implemented so far.
-     
-  See ``src/zope/cachedescriptors/method.txt``.
+
+  See ``src/zope/cachedescriptors/method.rst``.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ def read(*rnames):
 
 setup(
     name='zope.cachedescriptors',
-    version='4.2.1.dev0',
-    url='http://pypi.python.org/pypi/zope.cachedescriptors',
+    version='4.3.0.dev0',
+    url='http://github.com/zopefoundation/zope.cachedescriptors',
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.org',
     license='ZPL 2.1',
@@ -40,30 +40,35 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Operating System :: OS Independent',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development',
-        ],
+    ],
     description='Method and property caching decorators',
-    long_description=\
+    keywords='persistent caching decorator method property',
+    long_description=(
         read('README.rst')
         + '\n' +
-        read('src', 'zope', 'cachedescriptors', 'property.txt')
+        read('src', 'zope', 'cachedescriptors', 'property.rst')
         + '\n' +
-        read('src', 'zope', 'cachedescriptors', 'method.txt')
+        read('src', 'zope', 'cachedescriptors', 'method.rst')
         + '\n' +
-        read('CHANGES.rst'),
-
+        read('CHANGES.rst')),
     packages=find_packages('src'),
     package_dir={'': 'src'},
     test_suite='zope.cachedescriptors.tests.test_suite',
     namespace_packages=['zope',],
     include_package_data=True,
-    install_requires=['setuptools'],
+    install_requires=[
+        'setuptools',
+    ],
+    extras_require={
+        'test': [],
+    },
     zip_safe=False,
-    )
+)

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__('pkg_resources').declare_namespace(__name__) # pragma: no cover

--- a/src/zope/cachedescriptors/method.rst
+++ b/src/zope/cachedescriptors/method.rst
@@ -1,8 +1,9 @@
-Method Cache
-------------
+==============
+ Method Cache
+==============
 
 cachedIn
-~~~~~~~~
+========
 
 The `cachedIn` property allows to specify the attribute where to store the
 computed value:

--- a/src/zope/cachedescriptors/property.rst
+++ b/src/zope/cachedescriptors/property.rst
@@ -1,5 +1,6 @@
-Cached Properties
------------------
+===================
+ Cached Properties
+===================
 
 Cached properties are computed properties that cache their computed
 values.  They take into account instance attributes that they depend
@@ -7,9 +8,9 @@ on, so when the instance attributes change, the properties will change
 the values they return.
 
 CachedProperty
-~~~~~~~~~~~~~~
+==============
 
-Cached properties cache their data in _v_ attributes, so they are
+Cached properties cache their data in ``_v_`` attributes, so they are
 also useful for managing the computation of volatile attributes for
 persistent objects. Let's look at an example:
 
@@ -155,7 +156,7 @@ For backwards compatibility this can be written in a few different ways::
 
 
 Lazy Computed Attributes
-~~~~~~~~~~~~~~~~~~~~~~~~
+========================
 
 The `property` module provides another descriptor that supports a
 slightly different caching model: lazy attributes.  Like cached
@@ -256,7 +257,7 @@ This is the same behaviour as the standard Python ``property``
 decorator.
 
 readproperty
-~~~~~~~~~~~~
+============
 
 readproperties are like lazy computed attributes except that the
 attribute isn't set by the property:
@@ -309,7 +310,7 @@ the class. This allows Sphinx to extract the documentation.
     radius
 
 cachedIn
-~~~~~~~~
+========
 
 The `cachedIn` property allows to specify the attribute where to store the
 computed value:

--- a/src/zope/cachedescriptors/tests.py
+++ b/src/zope/cachedescriptors/tests.py
@@ -19,5 +19,5 @@ import doctest
 
 def test_suite():
     return doctest.DocFileSuite(
-        'property.txt', 'method.txt',
+        'property.rst', 'method.rst',
         optionflags=doctest.ELLIPSIS)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,16 @@
 [tox]
-envlist = py27,py33,py34,py35,pypy,pypy3
+envlist = py27,py34,py35,py36,pypy,pypy3
 
 [testenv]
+usedevelop = true
 commands = python setup.py -q test -q
-deps = zope.testrunner
+deps =
+     .[test]
+
+[testenv:coverage]
+commands =
+    coverage run setup.py -q test -q
+    coverage report
+deps =
+    {[testenv]deps}
+    coverage


### PR DESCRIPTION
- Enable coveralls and a local tox coverage environment.
- Rename .txt to .rst.
- Add missing badges to README.rst

(I *didn't* add `requires_python` to this one after reviewing the distutils-sig discussion on that and classifiers as mentioned in zopefoundation/zope.hookable#3. My take away was to only use `requires_python` if the software is actively known to be broken on the banned versions---so ZEO was a good use. Here, we're dropping testing of 3.3, but no code actually changed, so it still works there. Our requires python would then wind up being something like `>=2.7,!=3.0.*,!=3.1.*,!=3.2.*`, which probably doesn't add enough value at the moment to pay for itself.)

Refs zopefoundation/zopetoolkit#8