### PR TITLE
Add support for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: python
-sudo: false
 python:
     - 2.7
     - 3.4
     - 3.5
     - 3.6
-    - 3.7-dev
     - pypy
     - pypy3
+matrix:
+    include:
+        - python: 3.7
+          dist: xenial
 install:
     - pip install -U pip setuptools
     - pip install -U coverage coveralls

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,13 +5,13 @@
 4.3.2 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Add support for Python 3.7.
 
 
 4.3.1 (2017-12-09)
 ==================
 
-- Fix test which will break in the upcomming Python 3.7 release.
+- Fix test which will break in the upcoming Python 3.7 release.
 
 
 4.3.0 (2017-07-27)

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,pypy,pypy3
+envlist = py27,py34,py35,py36,py37,pypy,pypy3
 
 [testenv]
 usedevelop = true


### PR DESCRIPTION
My motivation for this was to shut up a warning from [`check-python-versions`](https://pypi.org/project/check-python-versions/):
```
setup.py says:              2.7, 3.4, 3.5, 3.6, PyPy
tox.ini says:               2.7, 3.4, 3.5, 3.6, PyPy, PyPy3
.travis.yml says:           2.7, 3.4, 3.5, 3.6, 3.7-dev, PyPy, PyPy3

mismatch!
```